### PR TITLE
Feat/merge from origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ docker mcp gateway run
 docker mcp gateway run --port 8080 --transport streaming
 ```
 
-More about [the MCP Gateway](docs/mcp-gateway.md).
+* more about [the MCP Gateway](docs/mcp-gateway.md)
+* [running an unpublished local image](docs/self-configured.md)
 
 ### Server Management
 

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -35,13 +35,12 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 			CatalogPath: []string{catalog.DockerCatalogURL},
 			SecretsPath: "docker-desktop:/run/secrets/mcp_secret:/.env",
 			Options: gateway.Options{
-				Cpus:             1,
-				Memory:           "2Gb",
-				Transport:        "stdio",
-				LogCalls:         true,
-				BlockSecrets:     true,
-				VerifySignatures: true,
-				Verbose:          true,
+				Cpus:         1,
+				Memory:       "2Gb",
+				Transport:    "stdio",
+				LogCalls:     true,
+				BlockSecrets: true,
+				Verbose:      true,
 			},
 		}
 	} else {

--- a/cmd/docker-mcp/oauth/auth.go
+++ b/cmd/docker-mcp/oauth/auth.go
@@ -96,6 +96,7 @@ func performAtomicDCRAndAuthorize(ctx context.Context, serverName string, scopes
 		ProviderName:          providerName,
 		AuthorizationEndpoint: credentials.AuthorizationEndpoint,
 		TokenEndpoint:         credentials.TokenEndpoint,
+		ResourceURL:           credentials.ServerURL,
 	}
 
 	if err := client.RegisterDCRClient(ctx, serverName, dcrRequest); err != nil {

--- a/docs/config-flow.md
+++ b/docs/config-flow.md
@@ -1,0 +1,68 @@
+# Gateway startup
+
+```mermaid
+sequenceDiagram
+    participant Gateway
+    participant Config
+    participant Configurator
+    participant Server
+    participant Listener
+
+    Gateway->>Listener: Start listening immediately if not-stdio
+    Gateway->>Configurator: Read
+    Configurator-->>Config: hello
+    Config-->>Gateway: configured
+    Configurator->>Watcher: channel
+    Watcher-->>Gateway: watch channel config changes
+    Gateway->>Gateway: pullAndVerify(config)
+    Gateway->>Gateway: reloadConfiguration(config)
+    Gateway->>Server: start
+    Gateway->>Listener: healthy
+```
+
+## Reading Config
+
+The `Read` method in `Configurator` is responsible for building an initial `Configuration`
+
+* serverNames
+* catalog.Servers (this is our catalog)
+    * read from catalog.yaml files
+    * read from oci artifacts
+* config map
+* tool filters
+* secret providers
+    * DD
+    * file
+
+## reloadConfiguration
+
+The gateway `reloadConfiguration` extracts capabilities from the current configuration, and updates the Server. It starts up the server to do this.
+
+When running servers raise change notifications, the capabilities also have to be reloaded.
+
+# Dynamic Server Add
+
+Another place where the capabilities should be considered _dynamic_ is with the `mcp-server-add` tool. This tool loads new mcp servers into a gateway session.
+
+```mermaid
+sequenceDiagram
+    AddTool->>Config: find
+    AddTool->>Config: append server
+    AddTool->>Config: update secrets
+    AddTool->>Gateway: reloadConfiguration
+    Gateway-->>Config: is used
+```
+
+During `reloadConfiguration` all updates to capabilities will cause change events to be sent to any clients connected to this server.
+
+# Images without Catalogs
+
+A Docker Image can contain it's own catalog description. If this is the case case the server oci reference is sufficient to populate the catalog.  In this case, `docker mcp gateway run --server docker.io/namespace/image:latest` will be sufficient to bootstrap the gateway. The requirement on this server is that it has a label like the following:
+
+```
+LABEL io.docker.server.metadata="{... server metadata ...}"
+```
+
+When the Configuration is first read, server names that are hub oci references will pulled, the label will be extracted, and we'll update both the list of serverNames, and the set of servers.
+
+

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -26,6 +26,9 @@ docker mcp gateway run --verbose --log-calls
 
 # Run in watch mode (auto-reload on config changes)
 docker mcp gateway run --watch
+
+# Run a standalone dockerized MCP server (no catalog required)
+docker mcp gateway run --server docker.io/namespace/repository:latest
 ```
 
 ## How to connect to an MCP Client?

--- a/docs/self-configured.md
+++ b/docs/self-configured.md
@@ -1,0 +1,52 @@
+## Self-Contained MCP Docker Image
+
+Before publishing an MCP server image, users can still run the MCP.
+
+```bash
+docker mcp gateway run --servers docker.io/namespace/repository:latest
+```
+
+* the `docker.io/` prefix is required here but we will inspect the tag `namespace/repository:latest` at runtime.
+
+## no catalog required
+
+In the example above, the namespace/repository:latest is not yet published, but it is available.
+
+The image must containi the following label.
+
+```
+LABEL io.docker.server.metadata="{... server metadata ...}"
+```
+
+### Example
+
+Build the image with the server metadata added to the label.
+
+```bash
+docker build \
+  --label "io.docker.server.metadata=$(cat <<'EOF'
+name: my-mcp-server
+description: "Custom MCP server for things"
+command: ["python", "/app/server.py"]
+env:
+  - name: LOG_LEVEL
+    value: "{{my-mcp-server.log-levell}}"
+  - name: DEBUG
+    value: "false"
+secrets:
+  - name: my-mcp-server.API_KEY
+    env: API_KEY
+config:
+  - name: my-mcp-server
+    type: object
+    properties:
+      log-level:
+        type: string
+    required:
+      - level
+EOF
+)" \
+  -t namespace/repository:latest .
+```
+
+* the `image` property is not required. This image is self-describing.

--- a/pkg/desktop/auth.go
+++ b/pkg/desktop/auth.go
@@ -81,6 +81,7 @@ type RegisterDCRRequest struct {
 	AuthorizationServer   string `json:"authorizationServer,omitempty"`
 	AuthorizationEndpoint string `json:"authorizationEndpoint,omitempty"`
 	TokenEndpoint         string `json:"tokenEndpoint,omitempty"`
+	ResourceURL           string `json:"resourceUrl,omitempty"`
 }
 
 type DCRClient struct {

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/docker/client"
@@ -26,6 +27,7 @@ type Client interface {
 	InspectContainer(ctx context.Context, containerID string) (container.InspectResponse, error)
 	ReadLogs(ctx context.Context, containerID string, options container.LogsOptions) (io.ReadCloser, error)
 	ImageExists(ctx context.Context, name string) (bool, error)
+	InspectImage(ctx context.Context, name string) (image.InspectResponse, error)
 	PullImage(ctx context.Context, name string) error
 	PullImages(ctx context.Context, names ...string) error
 	CreateNetwork(ctx context.Context, name string, internal bool, labels map[string]string) error

--- a/pkg/docker/images.go
+++ b/pkg/docker/images.go
@@ -46,6 +46,10 @@ func (c *dockerClient) PullImage(ctx context.Context, name string) error {
 	})
 }
 
+func (c *dockerClient) InspectImage(ctx context.Context, name string) (image.InspectResponse, error) {
+	return c.apiClient().ImageInspect(ctx, name)
+}
+
 func (c *dockerClient) pullImage(ctx context.Context, imageName string, registryAuthFn func() string) error {
 	inspect, err := c.apiClient().ImageInspect(ctx, imageName)
 	if err != nil && !cerrdefs.IsNotFound(err) {

--- a/pkg/gateway/configuration.go
+++ b/pkg/gateway/configuration.go
@@ -249,11 +249,24 @@ func (c *FileBasedConfiguration) readOnce(ctx context.Context) (Configuration, e
 		}
 	}
 
+	// check for docker.io self-contained servers
+	selfContainedCatalog, updatedServerNames, err := oci.SelfContainedCatalog(ctx, c.docker, serverNames)
+	if err != nil {
+		return Configuration{}, fmt.Errorf("reading oci server: %w", err)
+	}
+	serverNames = updatedServerNames
+
+	// read local caalog files
 	mcpCatalog, err := c.readCatalog(ctx)
 	if err != nil {
 		return Configuration{}, fmt.Errorf("reading catalog: %w", err)
 	}
+
+	// merge self-contained servers with local catalog
 	servers := mcpCatalog.Servers
+	for k, v := range selfContainedCatalog.Servers {
+		servers[k] = v
+	}
 
 	// Read servers from OCI references if any are provided
 	ociServers, err := c.readServersFromOci(ctx)

--- a/pkg/oci/self_contained.go
+++ b/pkg/oci/self_contained.go
@@ -1,0 +1,60 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/docker/mcp-gateway/pkg/catalog"
+	"github.com/docker/mcp-gateway/pkg/docker"
+)
+
+func SelfContainedCatalog(ctx context.Context, dockerClient docker.Client, serverNames []string) (catalog.Catalog, []string, error) {
+	result := catalog.Catalog{
+		Servers: make(map[string]catalog.Server),
+	}
+	var resultServerNames []string
+
+	for _, serverName := range serverNames {
+		if strings.HasPrefix(serverName, "docker.io/") {
+			ociRef := strings.TrimPrefix(serverName, "docker.io/")
+
+			if err := dockerClient.PullImage(ctx, ociRef); err != nil {
+				return catalog.Catalog{}, nil, fmt.Errorf("failed to pull OCI image %s: %w", ociRef, err)
+			}
+
+			inspect, err := dockerClient.InspectImage(ctx, ociRef)
+			if err != nil {
+				return catalog.Catalog{}, nil, fmt.Errorf("failed to inspect OCI image %s: %w", ociRef, err)
+			}
+
+			metadataLabel, exists := inspect.Config.Labels["io.docker.server.metadata"]
+			if !exists {
+				return catalog.Catalog{}, nil, fmt.Errorf("server name %s looks like an OCI ref but is missing the io.docker.server.metadata label", serverName)
+			}
+
+			var server catalog.Server
+			if err := yaml.Unmarshal([]byte(metadataLabel), &server); err != nil {
+				return catalog.Catalog{}, nil, fmt.Errorf("failed to parse metadata label for %s: %w", serverName, err)
+			}
+
+			server.Image = ociRef
+
+			// Determine the server name to use
+			finalServerName := serverName
+			if server.Name != "" {
+				finalServerName = server.Name
+			}
+
+			result.Servers[finalServerName] = server
+			resultServerNames = append(resultServerNames, finalServerName)
+		} else {
+			// Non-OCI server names are passed through as-is
+			resultServerNames = append(resultServerNames, serverName)
+		}
+	}
+
+	return result, resultServerNames, nil
+}


### PR DESCRIPTION
This pull request introduces support for running the MCP Gateway with self-contained Docker images that embed their own server catalog metadata, simplifying the process for users to run unpublished or standalone MCP servers. It also adds documentation and code changes to recognize and load these self-describing images, and includes minor improvements to the authentication and configuration flows.

**Self-contained Docker image support:**

* Added a new function `SelfContainedCatalog` in `pkg/oci/self_contained.go` to detect server names with the `docker.io/` prefix, pull the image, extract the `io.docker.server.metadata` label, and construct a catalog entry from it. This enables running MCP servers from images that are not yet published or do not require a separate catalog file.
* Updated the configuration loader in `pkg/gateway/configuration.go` to merge self-contained servers discovered via `SelfContainedCatalog` with the local catalog, and to update the list of server names accordingly.

**Docker client enhancements:**

* Extended the `docker.Client` interface and implementation to add `InspectImage`, which retrieves image metadata including labels, used by the self-contained catalog loader. [[1]](diffhunk://#diff-8bf93ad63bae86468a921c6200ea881313726b38dda047b8188330d1379aa161R30) [[2]](diffhunk://#diff-b1457746ebf1d5d0fbc08d9d97a6e71c2046501f57f5818f1d1621a1a289a732R49-R52) [[3]](diffhunk://#diff-8bf93ad63bae86468a921c6200ea881313726b38dda047b8188330d1379aa161R12)

**Documentation updates:**

* Added `docs/self-configured.md` and updated `README.md` and `docs/mcp-gateway.md` to document how to run the gateway with a self-contained MCP image, including build instructions and the required label format. [[1]](diffhunk://#diff-99dfb5240d867fe783cd19739e6884706db56bd42cf10003c8731b2bcfb9eb3dR1-R52) [[2]](diffhunk://#diff-ef579d18e783aadaf771ab014a308c6b0d7e006d85965b9bce8bd32d03073592R29-R31) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L102-R103)
* Added `docs/config-flow.md` to explain the gateway startup, configuration reading, dynamic server addition, and how images without catalogs are handled.

**Authentication improvements:**

* Added a `ResourceURL` field to the DCR registration request in both the struct and the code that creates it, ensuring the resource server URL is tracked during OAuth flows. [[1]](diffhunk://#diff-fbc296feb0ebcd12bbaadd2ad4ac1c87979f8279f88404dde9ebde17001175bfR84) [[2]](diffhunk://#diff-231456860fda55568563bcc03b3c04b7cbd56875937c3a74122279edfb257c1cR99)

**Default configuration adjustment:**

* Removed the `VerifySignatures` field from the default gateway command options, possibly to make signature verification optional or configurable elsewhere.**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**