### PR TITLE
Feat/types

### DIFF
--- a/docs/self-configured.md
+++ b/docs/self-configured.md
@@ -12,7 +12,7 @@ docker mcp gateway run --servers docker.io/namespace/repository:latest
 
 In the example above, the namespace/repository:latest is not yet published, but it is available.
 
-The image must containi the following label.
+The image must contain the following label:
 
 ```
 LABEL io.docker.server.metadata="{... server metadata ...}"

--- a/pkg/oci/self_contained.go
+++ b/pkg/oci/self_contained.go
@@ -18,9 +18,7 @@ func SelfContainedCatalog(ctx context.Context, dockerClient docker.Client, serve
 	var resultServerNames []string
 
 	for _, serverName := range serverNames {
-		if strings.HasPrefix(serverName, "docker.io/") {
-			ociRef := strings.TrimPrefix(serverName, "docker.io/")
-
+		if ociRef, ok := strings.CutPrefix(serverName, "docker.io/"); ok {
 			if err := dockerClient.PullImage(ctx, ociRef); err != nil {
 				return catalog.Catalog{}, nil, fmt.Errorf("failed to pull OCI image %s: %w", ociRef, err)
 			}


### PR DESCRIPTION
This pull request includes a minor documentation fix and a small code improvement related to handling Docker image references. The main changes are:

Documentation update:

* Fixed a typo and clarified the required image label in the `docs/self-configured.md` file.

Code improvement:

* Simplified the logic for handling Docker image references in the `SelfContainedCatalog` function by replacing `strings.HasPrefix` and `strings.TrimPrefix` with `strings.CutPrefix`, which improves code readability and efficiency.**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**