### PR TITLE
Feat/merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 .DS_Store
 **/.DS_Store
 /nix/
+/.mcp.json

--- a/docs/self-configured.md
+++ b/docs/self-configured.md
@@ -3,10 +3,10 @@
 Before publishing an MCP server image, users can still run the MCP.
 
 ```bash
-docker mcp gateway run --servers docker.io/namespace/repository:latest
+docker mcp gateway run --servers docker://namespace/repository:latest
 ```
 
-* the `docker.io/` prefix is required here but we will inspect the tag `namespace/repository:latest` at runtime.
+* the `docker://` prefix is required.
 
 ## no catalog required
 

--- a/pkg/oci/self_contained.go
+++ b/pkg/oci/self_contained.go
@@ -18,7 +18,8 @@ func SelfContainedCatalog(ctx context.Context, dockerClient docker.Client, serve
 	var resultServerNames []string
 
 	for _, serverName := range serverNames {
-		if ociRef, ok := strings.CutPrefix(serverName, "docker.io/"); ok {
+		if ociRef, ok := strings.CutPrefix(serverName, "docker://"); ok {
+
 			if err := dockerClient.PullImage(ctx, ociRef); err != nil {
 				return catalog.Catalog{}, nil, fmt.Errorf("failed to pull OCI image %s: %w", ociRef, err)
 			}


### PR DESCRIPTION
This pull request updates the way Docker image references are specified for running the MCP gateway and for internal image handling. The main change is switching from the `docker.io/` prefix to the `docker://` prefix when specifying Docker image sources, both in documentation and in code.

**User-facing documentation changes:**

* Updated the example command in `docs/self-configured.md` to require the `docker://` prefix instead of `docker.io/` for specifying server images.
* Clarified that the `docker://` prefix is required, removing mention of the `docker.io/` prefix.

**Internal image handling changes:**

* Changed the prefix check in `pkg/oci/self_contained.go` so that the code now recognizes and processes image references starting with `docker://` instead of `docker.io/`.**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**