### PR TITLE
Feat/merge origin

### DIFF
--- a/cmd/docker-mcp/client/config.yml
+++ b/cmd/docker-mcp/client/config.yml
@@ -17,6 +17,24 @@ system:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON
       del: del(.mcpServers[$NAME])
+  claude-code:
+    displayName: Claude Code
+    source: https://claude.ai/download
+    icon: https://raw.githubusercontent.com/docker/mcp-gateway/main/img/client/claude.svg
+    installCheckPaths:
+      - $HOME/.claude
+      - $USERPROFILE\.claude
+    paths:
+      linux:
+        - $HOME/.claude.json
+      darwin:
+        - $HOME/.claude.json
+      windows:
+        - $USERPROFILE\.claude.json
+    yq:
+      list: '.mcpServers | to_entries | map(.value + {"name": .key})'
+      set: .mcpServers[$NAME] = $JSON
+      del: del(.mcpServers[$NAME])
   continue:
     displayName: Continue.dev
     source: https://www.continue.dev/
@@ -124,6 +142,29 @@ system:
       list: '.mcpServers | to_entries | map(.value + {"name": .key})'
       set: .mcpServers[$NAME] = $JSON
       del: del(.mcpServers[$NAME])
+  opencode:
+    displayName: OpenCode
+    source: https://opencode.ai/
+    icon: https://avatars.githubusercontent.com/u/66570915?s=48&v=4
+    installCheckPaths:
+      - $HOME/.config/opencode
+      - $USERPROFILE\.config\opencode
+    paths:
+      linux:
+        - $HOME/.config/opencode/opencode.json
+      darwin:
+        - $HOME/.config/opencode/opencode.json
+      windows:
+        - $USERPROFILE\.config\opencode\opencode.json
+    yq:
+      list: '.mcp | to_entries | map({"name": .key, "command": .value.command[0], "args": (.value.command[1:] // []), "type": "stdio"})'
+      set: |
+        .mcp[$NAME] = {
+          "type": "local",
+          "command": [$JSON.command]+$JSON.args,
+          "enabled": true
+        }
+      del: del(.mcp[$NAME])
   sema4:
     displayName: Sema4.ai Studio
     source: https://sema4.ai/links/docker-mcp-download
@@ -177,3 +218,12 @@ project:
       list: '.servers | to_entries | map(.value + {"name": .key})'
       set: .servers[$NAME] = $JSON+{"type":"stdio"}
       del: del(.servers[$NAME])
+  claude-code:
+    displayname: Claude Code
+    projectfile: .mcp.json
+    icon: https://raw.githubusercontent.com/docker/mcp-gateway/main/img/client/claude.svg
+    yq:
+      list: '.mcpServers | to_entries | map(.value + {"name": .key})'
+      set: .mcpServers[$NAME] = $JSON+{"type":"stdio"}
+      del: del(.mcpServers[$NAME])
+

--- a/docs/generator/reference/docker_mcp_client_connect.yaml
+++ b/docs/generator/reference/docker_mcp_client_connect.yaml
@@ -1,12 +1,12 @@
 command: docker mcp client connect
 short: |
-    Connect the Docker MCP Toolkit to a client. Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed
+    Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 long: |
-    Connect the Docker MCP Toolkit to a client. Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed
+    Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 usage: |-
     docker mcp client connect [OPTIONS] <mcp-client>
 
-    Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed
+    Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 pname: docker mcp client
 plink: docker_mcp_client.yaml
 options:

--- a/docs/generator/reference/docker_mcp_client_disconnect.yaml
+++ b/docs/generator/reference/docker_mcp_client_disconnect.yaml
@@ -1,12 +1,12 @@
 command: docker mcp client disconnect
 short: |
-    Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed
+    Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 long: |
-    Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed
+    Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 usage: |-
     docker mcp client disconnect [OPTIONS] <mcp-client>
 
-    Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed
+    Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 pname: docker mcp client
 plink: docker_mcp_client.yaml
 options:

--- a/docs/generator/reference/mcp_client.md
+++ b/docs/generator/reference/mcp_client.md
@@ -5,11 +5,11 @@ Manage MCP clients
 
 ### Subcommands
 
-| Name                                     | Description                                                                                                                                      |
-|:-----------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`connect`](mcp_client_connect.md)       | Connect the Docker MCP Toolkit to a client. Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed      |
-| [`disconnect`](mcp_client_disconnect.md) | Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed |
-| [`ls`](mcp_client_ls.md)                 | List client configurations                                                                                                                       |
+| Name                                     | Description                                                                                                                                                           |
+|:-----------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`connect`](mcp_client_connect.md)       | Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed      |
+| [`disconnect`](mcp_client_disconnect.md) | Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed |
+| [`ls`](mcp_client_ls.md)                 | List client configurations                                                                                                                                            |
 
 
 

--- a/docs/generator/reference/mcp_client_connect.md
+++ b/docs/generator/reference/mcp_client_connect.md
@@ -1,7 +1,7 @@
 # docker mcp client connect
 
 <!---MARKER_GEN_START-->
-Connect the Docker MCP Toolkit to a client. Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed
+Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 
 ### Options
 

--- a/docs/generator/reference/mcp_client_disconnect.md
+++ b/docs/generator/reference/mcp_client_disconnect.md
@@ -1,7 +1,7 @@
 # docker mcp client disconnect
 
 <!---MARKER_GEN_START-->
-Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-desktop continue cursor gemini goose gordon lmstudio sema4 vscode zed
+Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 
 ### Options
 


### PR DESCRIPTION
This pull request adds support for two new clients, `claude-code` and `opencode`, to the Docker MCP Toolkit. The changes update configuration files and documentation to ensure these clients are recognized and properly integrated alongside existing supported clients.

New client integrations:

* Added configuration for `claude-code` in `cmd/docker-mcp/client/config.yml`, including display name, source, icon, install check paths, platform-specific paths, and YAML query commands for client management.
* Added configuration for `opencode` in `cmd/docker-mcp/client/config.yml`, with display name, source, icon, install check paths, platform-specific paths, and custom YAML query commands for client management.
* Updated project-level configuration for `claude-code` in `cmd/docker-mcp/client/config.yml`, specifying display name, project file, icon, and YAML query commands.

Documentation updates:

* Updated supported client lists in all relevant documentation files (`docker_mcp_client_connect.yaml`, `docker_mcp_client_disconnect.yaml`, `mcp_client.md`, `mcp_client_connect.md`, `mcp_client_disconnect.md`) to include `claude-code` and `opencode`. [[1]](diffhunk://#diff-ccf830401465d3c461c52b6af991bed8279ddd807ea2cff763b7739b0de872e9L3-R9) [[2]](diffhunk://#diff-0cd1300a3e3ac9a4582d119f94d187a24f04b16c3e7e336bfba340a8bdf2efeeL3-R9) [[3]](diffhunk://#diff-d858ed3d1c61f931e909b3be5f59cace45aa37ed1eadb2383a1a2e4673b0e844L9-R11) [[4]](diffhunk://#diff-a84e60555ce8380513017862064c9f274626dab7a8c773d0a76a3c0728cefa0bL4-R4) [[5]](diffhunk://#diff-d5ba6dae45115309cea6ee544e4e6310262e08a7a106837fd4a8537848799548L4-R4)