### PR TITLE
Chore/merge

### DIFF
--- a/cmd/docker-mcp/catalog/catalog.go
+++ b/cmd/docker-mcp/catalog/catalog.go
@@ -10,7 +10,8 @@ import (
 
 const (
 	DockerCatalogName     = "docker-mcp"
-	DockerCatalogURL      = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
+	DockerCatalogURLV2    = "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"
+	DockerCatalogURLV3    = "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml"
 	DockerCatalogFilename = "docker-mcp.yaml"
 
 	// Docker server names for bootstrap command
@@ -19,7 +20,15 @@ const (
 )
 
 var aliasToURL = map[string]string{
-	DockerCatalogName: DockerCatalogURL,
+	DockerCatalogName: DockerCatalogURLV2, // Default to v2 for backwards compatibility
+}
+
+// GetDockerCatalogURL returns the appropriate Docker catalog URL based on the mcp-oauth-dcr flag
+func GetDockerCatalogURL(mcpOAuthDcrEnabled bool) string {
+	if mcpOAuthDcrEnabled {
+		return DockerCatalogURLV3
+	}
+	return DockerCatalogURLV2
 }
 
 type MetaData struct {

--- a/cmd/docker-mcp/catalog/show.go
+++ b/cmd/docker-mcp/catalog/show.go
@@ -52,7 +52,7 @@ func SupportedFormats() string {
 	return strings.Join(quoted, ", ")
 }
 
-func Show(ctx context.Context, name string, format Format) error {
+func Show(ctx context.Context, name string, format Format, mcpOAuthDcrEnabled bool) error {
 	cfg, err := ReadConfigWithDefaultCatalog(ctx)
 	if err != nil {
 		return err
@@ -83,7 +83,7 @@ func Show(ctx context.Context, name string, format Format) error {
 		}
 	}
 	if needsUpdate {
-		if err := updateCatalog(ctx, name, catalog); err != nil {
+		if err := updateCatalog(ctx, name, catalog, mcpOAuthDcrEnabled); err != nil {
 			return err
 		}
 	}

--- a/cmd/docker-mcp/catalog/update.go
+++ b/cmd/docker-mcp/catalog/update.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
-func Update(ctx context.Context, args []string) error {
+func Update(ctx context.Context, args []string, mcpOAuthDcrEnabled bool) error {
 	cfg, err := ReadConfig()
 	if err != nil {
 		return err
@@ -30,7 +31,7 @@ func Update(ctx context.Context, args []string) error {
 		if !ok {
 			continue
 		}
-		if err := updateCatalog(ctx, name, catalog); err != nil {
+		if err := updateCatalog(ctx, name, catalog, mcpOAuthDcrEnabled); err != nil {
 			errs = append(errs, err)
 		}
 		fmt.Println("updated:", name)
@@ -47,16 +48,29 @@ func getAllCatalogNames(cfg Config) []string {
 	return names
 }
 
-func updateCatalog(ctx context.Context, name string, catalog Catalog) error {
+func updateCatalog(ctx context.Context, name string, catalog Catalog, mcpOAuthDcrEnabled bool) error {
 	url := catalog.URL
 
 	var (
 		catalogContent []byte
 		err            error
 	)
-	// For the docker catalog, use the default URL if none is set
-	if name == DockerCatalogName && (url == "" || !isValidURL(url)) {
-		url = DockerCatalogURL
+	// For the docker catalog, override URL to match the feature flag state if:
+	// 1. No URL is set or invalid, OR
+	// 2. The URL is an official v2/v3 catalog URL (prod or staging) that doesn't match the feature flag
+	// This preserves truly custom URLs while ensuring official catalogs switch between v2/v3.
+	if name == DockerCatalogName {
+		if url == "" || !isValidURL(url) {
+			url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
+		} else {
+			// If it's an official v2/v3 catalog URL, always use the URL that matches the feature flag
+			isV2URL := strings.Contains(url, "/catalog/v2/catalog.yaml")
+			isV3URL := strings.Contains(url, "/catalog/v3/catalog.yaml")
+
+			if isV2URL || isV3URL {
+				url = GetDockerCatalogURL(mcpOAuthDcrEnabled)
+			}
+		}
 	}
 
 	if isValidURL(url) {

--- a/cmd/docker-mcp/client/codex_handler.go
+++ b/cmd/docker-mcp/client/codex_handler.go
@@ -1,0 +1,182 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/pelletier/go-toml/v2"
+
+	"github.com/docker/mcp-gateway/pkg/user"
+)
+
+var installCheckPaths = []string{
+	"$HOME/.codex",
+	"$USERPROFILE\\.codex",
+}
+
+// isCodexInstalled checks if the codex binary is installed and working
+func isCodexInstalled(_ context.Context) bool {
+	for _, path := range installCheckPaths {
+		_, err := os.Stat(os.ExpandEnv(path))
+		if err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// getCodexSetup returns the configuration status for Codex
+func getCodexSetup(ctx context.Context) MCPClientCfg {
+	result := MCPClientCfg{
+		MCPClientCfgBase: MCPClientCfgBase{
+			DisplayName:           "Codex",
+			Source:                "https://openai.com/codex/",
+			Icon:                  "https://www.svgrepo.com/show/306500/openai.svg",
+			ConfigName:            vendorCodex,
+			Err:                   nil,
+			IsMCPCatalogConnected: false,
+		},
+		IsInstalled:   isCodexInstalled(ctx),
+		IsOsSupported: true,
+	}
+
+	// If Codex is not installed, return early
+	if !result.IsInstalled {
+		return result
+	}
+
+	// Check if docker mcp gateway is configured in codex config.toml
+	config, err := readCodexConfig()
+	if err != nil {
+		result.Err = classifyError(err)
+		return result
+	}
+
+	// Check if mcp_servers.DOCKER_MCP exists
+	if mcpServers, ok := config["mcp_servers"].(map[string]any); ok {
+		if dockerMCP, exists := mcpServers[DockerMCPCatalog]; exists && dockerMCP != nil {
+			result.IsMCPCatalogConnected = true
+			result.cfg = &MCPJSONLists{STDIOServers: []MCPServerSTDIO{{Name: DockerMCPCatalog}}}
+		}
+	}
+
+	return result
+}
+
+// getCodexConfigPath returns the path to the Codex config file
+func getCodexConfigPath() (string, error) {
+	home, err := user.HomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".codex", "config.toml"), nil
+}
+
+// MCPServerConfig represents the structure of an MCP server in config.toml
+type MCPServerConfig struct {
+	Command string   `toml:"command"`
+	Args    []string `toml:"args"`
+}
+
+// readCodexConfig reads and parses the Codex config.toml file
+func readCodexConfig() (map[string]any, error) {
+	configPath, err := getCodexConfigPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]any), nil
+		}
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var config map[string]any
+	if len(data) > 0 {
+		if err := toml.Unmarshal(data, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse config file: %w", err)
+		}
+	} else {
+		config = make(map[string]any)
+	}
+
+	return config, nil
+}
+
+// writeCodexConfig writes the config back to the Codex config.toml file
+func writeCodexConfig(config map[string]any) error {
+	configPath, err := getCodexConfigPath()
+	if err != nil {
+		return err
+	}
+
+	output, err := toml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, output, 0o644); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+// connectCodex configures docker mcp gateway in Codex by editing config.toml
+func connectCodex(_ context.Context) error {
+	config, err := readCodexConfig()
+	if err != nil {
+		return err
+	}
+
+	// Ensure mcp_servers section exists
+	mcpServers, ok := config["mcp_servers"].(map[string]any)
+	if !ok {
+		mcpServers = make(map[string]any)
+		config["mcp_servers"] = mcpServers
+	}
+
+	// Determine command and args based on platform
+	command := "docker"
+	if runtime.GOOS == "windows" {
+		command = "docker.exe"
+	}
+	args := []string{"mcp", "gateway", "run"}
+
+	// Add DOCKER_MCP entry
+	mcpServers[DockerMCPCatalog] = MCPServerConfig{
+		Command: command,
+		Args:    args,
+	}
+
+	return writeCodexConfig(config)
+}
+
+// disconnectCodex removes docker mcp gateway from Codex by editing config.toml
+func disconnectCodex(_ context.Context) error {
+	config, err := readCodexConfig()
+	if err != nil {
+		return err
+	}
+
+	// Remove DOCKER_MCP entry from mcp_servers
+	if mcpServers, ok := config["mcp_servers"].(map[string]any); ok {
+		delete(mcpServers, DockerMCPCatalog)
+
+		// If mcp_servers is now empty, remove the section
+		if len(mcpServers) == 0 {
+			delete(config, "mcp_servers")
+		}
+	}
+
+	return writeCodexConfig(config)
+}

--- a/cmd/docker-mcp/client/config.go
+++ b/cmd/docker-mcp/client/config.go
@@ -52,6 +52,7 @@ func findGitProjectRoot(dir string) string {
 func GetSupportedMCPClients(cfg Config) []string {
 	tmp := map[string]struct{}{
 		vendorGordon: {},
+		vendorCodex:  {},
 	}
 	for k := range cfg.System {
 		tmp[k] = struct{}{}

--- a/cmd/docker-mcp/client/connect.go
+++ b/cmd/docker-mcp/client/connect.go
@@ -6,7 +6,14 @@ import (
 )
 
 func Connect(ctx context.Context, cwd string, config Config, vendor string, global, quiet bool) error {
-	if vendor == vendorGordon && global {
+	if vendor == vendorCodex {
+		if !global {
+			return fmt.Errorf("codex only supports global configuration. Re-run with --global or -g")
+		}
+		if err := connectCodex(ctx); err != nil {
+			return err
+		}
+	} else if vendor == vendorGordon && global {
 		if err := connectGordon(ctx); err != nil {
 			return err
 		}

--- a/cmd/docker-mcp/client/disconnect.go
+++ b/cmd/docker-mcp/client/disconnect.go
@@ -6,7 +6,14 @@ import (
 )
 
 func Disconnect(ctx context.Context, cwd string, config Config, vendor string, global, quiet bool) error {
-	if vendor == vendorGordon && global {
+	if vendor == vendorCodex {
+		if !global {
+			return fmt.Errorf("codex only supports global configuration. Re-run with --global or -g")
+		}
+		if err := disconnectCodex(ctx); err != nil {
+			return err
+		}
+	} else if vendor == vendorGordon && global {
 		if err := disconnectGordon(ctx); err != nil {
 			return err
 		}

--- a/cmd/docker-mcp/client/ls.go
+++ b/cmd/docker-mcp/client/ls.go
@@ -16,6 +16,7 @@ const (
 	vendorContinueDev   = "continue"
 	vendorGordon        = "gordon"
 	vendorZed           = "zed"
+	vendorCodex         = "codex"
 )
 
 const (
@@ -180,5 +181,6 @@ func parseGlobalConfigs(ctx context.Context, config Config) GlobalConfig {
 	if err == nil {
 		result[vendorGordon] = getGordonSetup(ctx)
 	}
+	result[vendorCodex] = getCodexSetup(ctx)
 	return result
 }

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -31,8 +31,9 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 	var enableAllServers bool
 	if os.Getenv("DOCKER_MCP_IN_CONTAINER") == "1" {
 		// In-container.
+		// Note: The catalog URL will be updated after checking the feature flag in RunE
 		options = gateway.Config{
-			CatalogPath: []string{catalog.DockerCatalogURL},
+			CatalogPath: []string{catalog.DockerCatalogURLV2}, // Default to v2, will be updated based on flag
 			SecretsPath: "docker-desktop:/run/secrets/mcp_secret:/.env",
 			Options: gateway.Options{
 				Cpus:         1,
@@ -76,6 +77,11 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 			// Check if dynamic tools feature is enabled
 			options.DynamicTools = isDynamicToolsFeatureEnabled(dockerCli)
 
+			// Update catalog URL based on mcp-oauth-dcr flag if using default Docker catalog URL
+			if len(options.CatalogPath) == 1 && (options.CatalogPath[0] == catalog.DockerCatalogURLV2 || options.CatalogPath[0] == catalog.DockerCatalogURLV3) {
+				options.CatalogPath[0] = catalog.GetDockerCatalogURL(options.McpOAuthDcrEnabled)
+			}
+
 			if options.Static {
 				options.Watch = false
 			}
@@ -98,7 +104,7 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 
 			// Only add configured catalogs if defaultPaths is not a single Docker catalog entry
 			var configuredPaths []string
-			if len(defaultPaths) == 1 && (defaultPaths[0] == catalog.DockerCatalogURL || defaultPaths[0] == catalog.DockerCatalogFilename) {
+			if len(defaultPaths) == 1 && (defaultPaths[0] == catalog.DockerCatalogURLV2 || defaultPaths[0] == catalog.DockerCatalogURLV3 || defaultPaths[0] == catalog.DockerCatalogFilename) {
 				configuredPaths = getConfiguredCatalogPaths()
 			}
 			catalogPaths := buildUniqueCatalogPaths(defaultPaths, configuredPaths, additionalCatalogs)

--- a/cmd/docker-mcp/commands/gateway_test.go
+++ b/cmd/docker-mcp/commands/gateway_test.go
@@ -227,13 +227,22 @@ func TestBuildUniqueCatalogPaths(t *testing.T) {
 }
 
 func TestConditionalConfiguredCatalogPaths(t *testing.T) {
-	t.Run("excludes configured catalogs when single Docker catalog URL", func(t *testing.T) {
-		// Test the logic for when defaultPaths contains only DockerCatalogURL
+	t.Run("excludes configured catalogs when single Docker catalog URL v2", func(t *testing.T) {
+		// Test the logic for when defaultPaths contains only DockerCatalogURLV2
 		defaultPaths := []string{"https://desktop.docker.com/mcp/catalog/v2/catalog.yaml"}
 
 		// This should match the condition and return empty configuredPaths
-		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
-		assert.True(t, shouldExclude, "should exclude configured catalogs when single Docker catalog URL")
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		assert.True(t, shouldExclude, "should exclude configured catalogs when single Docker catalog URL v2")
+	})
+
+	t.Run("excludes configured catalogs when single Docker catalog URL v3", func(t *testing.T) {
+		// Test the logic for when defaultPaths contains only DockerCatalogURLV3
+		defaultPaths := []string{"https://desktop.docker.com/mcp/catalog/v3/catalog.yaml"}
+
+		// This should match the condition and return empty configuredPaths
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		assert.True(t, shouldExclude, "should exclude configured catalogs when single Docker catalog URL v3")
 	})
 
 	t.Run("excludes configured catalogs when single Docker catalog filename", func(t *testing.T) {
@@ -241,7 +250,7 @@ func TestConditionalConfiguredCatalogPaths(t *testing.T) {
 		defaultPaths := []string{"docker-mcp.yaml"}
 
 		// This should match the condition and return empty configuredPaths
-		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
 		assert.True(t, shouldExclude, "should exclude configured catalogs when single Docker catalog filename")
 	})
 
@@ -250,7 +259,7 @@ func TestConditionalConfiguredCatalogPaths(t *testing.T) {
 		defaultPaths := []string{"docker-mcp.yaml", "other-catalog.yaml"}
 
 		// This should NOT match the condition and allow configuredPaths
-		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
 		assert.False(t, shouldExclude, "should include configured catalogs when multiple paths")
 	})
 
@@ -259,7 +268,7 @@ func TestConditionalConfiguredCatalogPaths(t *testing.T) {
 		defaultPaths := []string{"custom-catalog.yaml"}
 
 		// This should NOT match the condition and allow configuredPaths
-		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
+		shouldExclude := len(defaultPaths) == 1 && (defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v2/catalog.yaml" || defaultPaths[0] == "https://desktop.docker.com/mcp/catalog/v3/catalog.yaml" || defaultPaths[0] == "docker-mcp.yaml")
 		assert.False(t, shouldExclude, "should include configured catalogs when single non-Docker catalog")
 	})
 }

--- a/cmd/docker-mcp/commands/root.go
+++ b/cmd/docker-mcp/commands/root.go
@@ -70,7 +70,7 @@ func Root(ctx context.Context, cwd string, dockerCli command.Cli) *cobra.Command
 
 	dockerClient := docker.NewClient(dockerCli)
 
-	cmd.AddCommand(catalogCommand())
+	cmd.AddCommand(catalogCommand(dockerCli))
 	cmd.AddCommand(clientCommand(cwd))
 	cmd.AddCommand(configCommand(dockerClient))
 	cmd.AddCommand(featureCommand(dockerCli))

--- a/docs/generator/reference/docker_mcp_catalog_show.yaml
+++ b/docs/generator/reference/docker_mcp_catalog_show.yaml
@@ -16,7 +16,12 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
-examples: "  # Show Docker's official catalog\n  docker mcp catalog show\n  \n  # Show a specific catalog in JSON format\n  docker mcp catalog show my-catalog --format=json"
+examples: |4-
+      # Show Docker's official catalog
+      docker mcp catalog show
+
+      # Show a specific catalog in JSON format
+      docker mcp catalog show my-catalog --format=json
 deprecated: false
 hidden: false
 experimental: false

--- a/docs/generator/reference/docker_mcp_catalog_update.yaml
+++ b/docs/generator/reference/docker_mcp_catalog_update.yaml
@@ -6,7 +6,12 @@ long: |-
 usage: docker mcp catalog update [name]
 pname: docker mcp catalog
 plink: docker_mcp_catalog.yaml
-examples: "  # Update all catalogs\n  docker mcp catalog update\n  \n  # Update specific catalog\n  docker mcp catalog update team-servers"
+examples: |4-
+      # Update all catalogs
+      docker mcp catalog update
+
+      # Update specific catalog
+      docker mcp catalog update team-servers
 deprecated: false
 hidden: false
 experimental: false

--- a/docs/generator/reference/docker_mcp_client_connect.yaml
+++ b/docs/generator/reference/docker_mcp_client_connect.yaml
@@ -1,12 +1,12 @@
 command: docker mcp client connect
 short: |
-    Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
+    Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 long: |
-    Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
+    Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 usage: |-
     docker mcp client connect [OPTIONS] <mcp-client>
 
-    Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
+    Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 pname: docker mcp client
 plink: docker_mcp_client.yaml
 options:

--- a/docs/generator/reference/docker_mcp_client_disconnect.yaml
+++ b/docs/generator/reference/docker_mcp_client_disconnect.yaml
@@ -1,12 +1,12 @@
 command: docker mcp client disconnect
 short: |
-    Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
+    Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 long: |
-    Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
+    Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 usage: |-
     docker mcp client disconnect [OPTIONS] <mcp-client>
 
-    Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
+    Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 pname: docker mcp client
 plink: docker_mcp_client.yaml
 options:

--- a/docs/generator/reference/mcp_client.md
+++ b/docs/generator/reference/mcp_client.md
@@ -5,11 +5,11 @@ Manage MCP clients
 
 ### Subcommands
 
-| Name                                     | Description                                                                                                                                                           |
-|:-----------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`connect`](mcp_client_connect.md)       | Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed      |
-| [`disconnect`](mcp_client_disconnect.md) | Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed |
-| [`ls`](mcp_client_ls.md)                 | List client configurations                                                                                                                                            |
+| Name                                     | Description                                                                                                                                                                 |
+|:-----------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`connect`](mcp_client_connect.md)       | Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed      |
+| [`disconnect`](mcp_client_disconnect.md) | Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed |
+| [`ls`](mcp_client_ls.md)                 | List client configurations                                                                                                                                                  |
 
 
 

--- a/docs/generator/reference/mcp_client_connect.md
+++ b/docs/generator/reference/mcp_client_connect.md
@@ -1,7 +1,7 @@
 # docker mcp client connect
 
 <!---MARKER_GEN_START-->
-Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
+Connect the Docker MCP Toolkit to a client. Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 
 ### Options
 

--- a/docs/generator/reference/mcp_client_disconnect.md
+++ b/docs/generator/reference/mcp_client_disconnect.md
@@ -1,7 +1,7 @@
 # docker mcp client disconnect
 
 <!---MARKER_GEN_START-->
-Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
+Disconnect the Docker MCP Toolkit from a client. Supported clients: claude-code claude-desktop codex continue cursor gemini goose gordon lmstudio opencode sema4 vscode zed
 
 ### Options
 

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -65,7 +65,7 @@ services:
 + Starts an MCP Gateway for other services to use. Think AI Agents.
 + Work independently from Docker Desktop's MCP Toolkit. It can run anywhere there's a Docker engine.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 
 ### How to run
 

--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -4,7 +4,7 @@ This example shows how to call the MCP Gateway from a python client:
 
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 + Uses the latest http streaming transport.
 
 ## How to run

--- a/examples/interceptors/README.md
+++ b/examples/interceptors/README.md
@@ -4,7 +4,7 @@ This example shows how to call the MCP Gateway from a python client:
 
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 + Uses the latest http streaming transport.
 
 ## How to run

--- a/examples/minimal-compose/README.md
+++ b/examples/minimal-compose/README.md
@@ -5,7 +5,7 @@ This is a very minimalist example of running the MCP Gateway with Docker Compose
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
 + Doesn't define any secret.
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 
 ## How to run
 

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -5,7 +5,7 @@ This is a simple example of running the MCP Gateway with Docker Compose:
 + Doesn't rely on the MCP Toolkit UI. Can run anywhere, even if Docker Desktop is not available.
 + Defines the list of enabled servers from the gateway's command line, with `--server`
 + Defines secrets in an `.env` file.
-+ Uses the online Docker MCP Catalog hosted on http://desktop.docker.com/mcp/catalog/v2/catalog.yaml.
++ Uses the online Docker MCP Catalog (v2: http://desktop.docker.com/mcp/catalog/v2/catalog.yaml by default, v3: http://desktop.docker.com/mcp/catalog/v3/catalog.yaml when `mcp-oauth-dcr` feature is enabled).
 
 ## How to run
 

--- a/pkg/integration_test.go
+++ b/pkg/integration_test.go
@@ -146,7 +146,7 @@ func TestIntegrationDryRunEmpty(t *testing.T) {
 
 func TestIntegrationDryRunFetch(t *testing.T) {
 	thisIsAnIntegrationTest(t)
-	out := runDockerMCP(t, "gateway", "run", "--dry-run", "--servers=fetch", "--catalog="+catalog.DockerCatalogURL)
+	out := runDockerMCP(t, "gateway", "run", "--dry-run", "--servers=fetch", "--catalog="+catalog.DockerCatalogURLV2)
 	assert.Contains(t, out, "fetch: (1 tools)")
 	assert.Contains(t, out, "Initialized in")
 }
@@ -178,7 +178,7 @@ func TestIntegrationCallToolDuckDuckDb(t *testing.T) {
 	thisIsAnIntegrationTest(t)
 	gatewayArgs := []string{
 		"--servers=duckduckgo",
-		"--catalog=" + catalog.DockerCatalogURL,
+		"--catalog=" + catalog.DockerCatalogURLV2,
 	}
 
 	out := runDockerMCP(t, "tools", "call", "--gateway-arg="+strings.Join(gatewayArgs, ","), "search", "query=Docker")


### PR DESCRIPTION
This pull request introduces support for the OpenAI Codex client in the MCP gateway and improves catalog version management, particularly around the Docker official catalog. The changes ensure that the correct catalog version (v2 or v3) is used based on feature flags, and add robust handling for connecting/disconnecting Codex as an MCP client. Several code paths and tests are updated to handle these new behaviors.

**Codex Client Integration:**
- Added support for the OpenAI Codex client, including detection of installation, reading/writing its configuration (`config.toml`), and connecting/disconnecting the Docker MCP gateway as a server within Codex. Codex is now treated as a supported MCP client alongside Gordon. [[1]](diffhunk://#diff-5dbdc62949f6523bd65c2998cbbfa8ecacdac1a0c3b9afd6abff5c85e4cc4c87R1-R182) [[2]](diffhunk://#diff-35c9a86f0b7992097045b826b07b6297f9b72befc1597f68c93965fd0fb607bdR55) [[3]](diffhunk://#diff-b6c8b7b420f355f54547d996dcff85b36d83dba7c53eb33b5b0f51ed4cfb8563R19) [[4]](diffhunk://#diff-b6c8b7b420f355f54547d996dcff85b36d83dba7c53eb33b5b0f51ed4cfb8563R184) [[5]](diffhunk://#diff-3279660b736a36cfc87f6e26717f60d30bd4cef8e61c4cb705f3022e1c9592e6L9-R16) [[6]](diffhunk://#diff-700a9aa9abe989c7031b5e609fb88ec3a7d4a02dba90190dfa17cb8fbb8b871bL9-R16)

**Docker Catalog Version Management:**
- Introduced separate constants for Docker catalog v2 and v3 URLs, and a new function `GetDockerCatalogURL` to select the appropriate version based on the `mcp-oauth-dcr` feature flag. The catalog update and show logic now dynamically select the correct URL and preserve custom URLs. [[1]](diffhunk://#diff-6daa999b16e2ceb960be0ad9238d02454a07816ff109026468d0dfffdbc8993dL13-R14) [[2]](diffhunk://#diff-6daa999b16e2ceb960be0ad9238d02454a07816ff109026468d0dfffdbc8993dL22-R31) [[3]](diffhunk://#diff-e1cb38ca2a6da030692a063a71c68c27785244295149801db6ba19a805a063fdR8-R12) [[4]](diffhunk://#diff-e1cb38ca2a6da030692a063a71c68c27785244295149801db6ba19a805a063fdL33-R34) [[5]](diffhunk://#diff-e1cb38ca2a6da030692a063a71c68c27785244295149801db6ba19a805a063fdL50-R73) [[6]](diffhunk://#diff-26a5b8550575668b9aa506bac036edcc02c830c5d66ec386f9be6125ab8be61fL55-R55) [[7]](diffhunk://#diff-26a5b8550575668b9aa506bac036edcc02c830c5d66ec386f9be6125ab8be61fL86-R86)
- Updated the CLI and gateway command logic to use the correct catalog URL version and to pass the feature flag state through to catalog operations. [[1]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eR8-R16) [[2]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eL27-R29) [[3]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eL126-R127) [[4]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eL139-R146) [[5]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eL165-R168) [[6]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709R34-R36) [[7]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709R80-R84) [[8]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709L101-R107)

**Testing Improvements:**
- Expanded and updated tests to cover both v2 and v3 Docker catalog URLs, ensuring correct behavior when determining whether to include configured catalogs. [[1]](diffhunk://#diff-4091e29622315d9856ed2562de87fe590d05ca65cdfd591e22780e56970ad10aL230-R253) [[2]](diffhunk://#diff-4091e29622315d9856ed2562de87fe590d05ca65cdfd591e22780e56970ad10aL253-R262) [[3]](diffhunk://#diff-4091e29622315d9856ed2562de87fe590d05ca65cdfd591e22780e56970ad10aL262-R271)

These changes together enhance the flexibility and robustness of MCP client and catalog handling.

---

**Codex Client Integration**
- Added new file `cmd/docker-mcp/client/codex_handler.go` implementing detection, configuration, and connect/disconnect logic for Codex as an MCP client.
- Registered Codex as a supported MCP client and included its setup in global configuration parsing. [[1]](diffhunk://#diff-35c9a86f0b7992097045b826b07b6297f9b72befc1597f68c93965fd0fb607bdR55) [[2]](diffhunk://#diff-b6c8b7b420f355f54547d996dcff85b36d83dba7c53eb33b5b0f51ed4cfb8563R19) [[3]](diffhunk://#diff-b6c8b7b420f355f54547d996dcff85b36d83dba7c53eb33b5b0f51ed4cfb8563R184)
- Updated connect and disconnect commands to handle Codex, enforcing global configuration and invoking Codex-specific logic. [[1]](diffhunk://#diff-3279660b736a36cfc87f6e26717f60d30bd4cef8e61c4cb705f3022e1c9592e6L9-R16) [[2]](diffhunk://#diff-700a9aa9abe989c7031b5e609fb88ec3a7d4a02dba90190dfa17cb8fbb8b871bL9-R16)

**Docker Catalog Version Management**
- Split Docker catalog URL constants into `DockerCatalogURLV2` and `DockerCatalogURLV3`, and added `GetDockerCatalogURL` to select the correct version based on the `mcp-oauth-dcr` flag. [[1]](diffhunk://#diff-6daa999b16e2ceb960be0ad9238d02454a07816ff109026468d0dfffdbc8993dL13-R14) [[2]](diffhunk://#diff-6daa999b16e2ceb960be0ad9238d02454a07816ff109026468d0dfffdbc8993dL22-R31)
- Updated catalog update and show logic to pass the feature flag and select the correct catalog URL, including preserving custom URLs. [[1]](diffhunk://#diff-e1cb38ca2a6da030692a063a71c68c27785244295149801db6ba19a805a063fdR8-R12) [[2]](diffhunk://#diff-e1cb38ca2a6da030692a063a71c68c27785244295149801db6ba19a805a063fdL33-R34) [[3]](diffhunk://#diff-e1cb38ca2a6da030692a063a71c68c27785244295149801db6ba19a805a063fdL50-R73) [[4]](diffhunk://#diff-26a5b8550575668b9aa506bac036edcc02c830c5d66ec386f9be6125ab8be61fL55-R55) [[5]](diffhunk://#diff-26a5b8550575668b9aa506bac036edcc02c830c5d66ec386f9be6125ab8be61fL86-R86)
- Updated CLI and gateway commands to pass the feature flag and use the correct catalog URL version. [[1]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eR8-R16) [[2]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eL27-R29) [[3]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eL126-R127) [[4]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eL139-R146) [[5]](diffhunk://#diff-5c9f01a67e9937b0a22e68038669a05d51497a197a953b0359d210c9cb0f443eL165-R168) [[6]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709R34-R36) [[7]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709R80-R84) [[8]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709L101-R107)

**Testing Improvements**
- Enhanced tests to cover both v2 and v3 Docker catalog URLs when determining catalog inclusion/exclusion logic. [[1]](diffhunk://#diff-4091e29622315d9856ed2562de87fe590d05ca65cdfd591e22780e56970ad10aL230-R253) [[2]](diffhunk://#diff-4091e29622315d9856ed2562de87fe590d05ca65cdfd591e22780e56970ad10aL253-R262) [[3]](diffhunk://#diff-4091e29622315d9856ed2562de87fe590d05ca65cdfd591e22780e56970ad10aL262-R271)**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**