### PR TITLE
Develop

### DIFF
--- a/cmd/docker-mcp/commands/client.go
+++ b/cmd/docker-mcp/commands/client.go
@@ -12,18 +12,19 @@ import (
 
 	clientcli "github.com/docker/mcp-gateway/cmd/docker-mcp/client"
 	"github.com/docker/mcp-gateway/pkg/client"
+	"github.com/docker/mcp-gateway/pkg/features"
 )
 
-func clientCommand(dockerCli command.Cli, cwd string) *cobra.Command {
+func clientCommand(dockerCli command.Cli, cwd string, features features.Features) *cobra.Command {
 	cfg := client.ReadConfig()
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("client (Supported: %s)", strings.Join(client.GetSupportedMCPClients(*cfg), ", ")),
 		Short: "Manage MCP clients",
 	}
 	cmd.AddCommand(listClientCommand(cwd, *cfg))
-	cmd.AddCommand(connectClientCommand(dockerCli, cwd, *cfg))
+	cmd.AddCommand(connectClientCommand(dockerCli, cwd, *cfg, features))
 	cmd.AddCommand(disconnectClientCommand(cwd, *cfg))
-	cmd.AddCommand(manualClientCommand(dockerCli))
+	cmd.AddCommand(manualClientCommand(features))
 	return cmd
 }
 
@@ -46,7 +47,7 @@ func listClientCommand(cwd string, cfg client.Config) *cobra.Command {
 	return cmd
 }
 
-func connectClientCommand(dockerCli command.Cli, cwd string, cfg client.Config) *cobra.Command {
+func connectClientCommand(dockerCli command.Cli, cwd string, cfg client.Config, features features.Features) *cobra.Command {
 	var opts struct {
 		Global     bool
 		Quiet      bool
@@ -63,7 +64,7 @@ func connectClientCommand(dockerCli command.Cli, cwd string, cfg client.Config) 
 	flags := cmd.Flags()
 	addGlobalFlag(flags, &opts.Global)
 	addQuietFlag(flags, &opts.Quiet)
-	if isWorkingSetsFeatureEnabled(dockerCli) {
+	if features.IsProfilesFeatureEnabled() {
 		addWorkingSetFlag(flags, &opts.WorkingSet)
 	}
 	return cmd
@@ -88,7 +89,7 @@ func disconnectClientCommand(cwd string, cfg client.Config) *cobra.Command {
 	return cmd
 }
 
-func manualClientCommand(dockerCli command.Cli) *cobra.Command {
+func manualClientCommand(features features.Features) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "manual-instructions",
 		Short: "Display the manual instructions to connect the MCP client",
@@ -100,7 +101,7 @@ func manualClientCommand(dockerCli command.Cli) *cobra.Command {
 			}
 
 			command := []string{"docker", "mcp", "gateway", "run"}
-			if isWorkingSetsFeatureEnabled(dockerCli) {
+			if features.IsProfilesFeatureEnabled() {
 				gordonProfile, err := client.ReadGordonProfile()
 				if err != nil {
 					return fmt.Errorf("failed to read gordon profile: %w", err)

--- a/cmd/docker-mcp/commands/feature.go
+++ b/cmd/docker-mcp/commands/feature.go
@@ -7,10 +7,12 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/spf13/cobra"
+
+	"github.com/docker/mcp-gateway/pkg/features"
 )
 
 // featureCommand creates the `feature` command and its subcommands
-func featureCommand(dockerCli command.Cli) *cobra.Command {
+func featureCommand(dockerCli command.Cli, features features.Features) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "feature",
 		Short: "Manage experimental features",
@@ -21,16 +23,16 @@ and control optional functionality that may change in future versions.`,
 	}
 
 	cmd.AddCommand(
-		featureEnableCommand(dockerCli),
-		featureDisableCommand(dockerCli),
-		featureListCommand(dockerCli),
+		featureEnableCommand(dockerCli, features),
+		featureDisableCommand(dockerCli, features),
+		featureListCommand(dockerCli, features),
 	)
 
 	return cmd
 }
 
 // featureEnableCommand creates the `feature enable` command
-func featureEnableCommand(dockerCli command.Cli) *cobra.Command {
+func featureEnableCommand(dockerCli command.Cli, features features.Features) *cobra.Command {
 	return &cobra.Command{
 		Use:   "enable <feature-name>",
 		Short: "Enable an experimental feature",
@@ -40,15 +42,15 @@ Available features:
   oauth-interceptor      Enable GitHub OAuth flow interception for automatic authentication
   mcp-oauth-dcr          Enable Dynamic Client Registration (DCR) for automatic OAuth client setup
   dynamic-tools          Enable internal MCP management tools (mcp-find, mcp-add, mcp-remove)
-	profiles               Enable profile management (docker mcp profile <subcommand>)
-  tool-name-prefix       Prefix all tool names with server name to avoid conflicts`,
+	` + notDockerDesktop(features, `profiles               Enable profile management (docker mcp profile <subcommand>)
+  `) + `tool-name-prefix       Prefix all tool names with server name to avoid conflicts`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			featureName := args[0]
 
 			// Validate feature name
-			if !isKnownFeature(featureName) {
-				return fmt.Errorf("unknown feature: %s\n\nAvailable features:\n  oauth-interceptor      Enable GitHub OAuth flow interception\n  mcp-oauth-dcr          Enable Dynamic Client Registration for automatic OAuth setup\n  dynamic-tools          Enable internal MCP management tools\n  profiles               Enable profile management (docker mcp profile <subcommand>)\n  tool-name-prefix       Prefix all tool names with server name", featureName)
+			if !isKnownFeature(featureName, features) {
+				return fmt.Errorf("unknown feature: %s\n\nAvailable features:\n  oauth-interceptor      Enable GitHub OAuth flow interception\n  mcp-oauth-dcr          Enable Dynamic Client Registration for automatic OAuth setup\n  dynamic-tools          Enable internal MCP management tools\n"+notDockerDesktop(features, "  profiles               Enable profile management (docker mcp profile <subcommand>)\n")+"  tool-name-prefix       Prefix all tool names with server name", featureName)
 			}
 
 			// Enable the feature
@@ -105,7 +107,7 @@ Available features:
 }
 
 // featureDisableCommand creates the `feature disable` command
-func featureDisableCommand(dockerCli command.Cli) *cobra.Command {
+func featureDisableCommand(dockerCli command.Cli, features features.Features) *cobra.Command {
 	return &cobra.Command{
 		Use:   "disable <feature-name>",
 		Short: "Disable an experimental feature",
@@ -115,7 +117,7 @@ func featureDisableCommand(dockerCli command.Cli) *cobra.Command {
 			featureName := args[0]
 
 			// Validate feature name
-			if !isKnownFeature(featureName) {
+			if !isKnownFeature(featureName, features) {
 				return fmt.Errorf("unknown feature: %s", featureName)
 			}
 
@@ -138,7 +140,7 @@ func featureDisableCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 // featureListCommand creates the `feature list` command
-func featureListCommand(dockerCli command.Cli) *cobra.Command {
+func featureListCommand(dockerCli command.Cli, features features.Features) *cobra.Command {
 	return &cobra.Command{
 		Use:     "ls",
 		Aliases: []string{"list"},
@@ -151,7 +153,10 @@ func featureListCommand(dockerCli command.Cli) *cobra.Command {
 			fmt.Println()
 
 			// Show all known features
-			knownFeatures := []string{"oauth-interceptor", "mcp-oauth-dcr", "dynamic-tools", "profiles", "tool-name-prefix"}
+			knownFeatures := []string{"oauth-interceptor", "mcp-oauth-dcr", "dynamic-tools", "tool-name-prefix"}
+			if !features.IsRunningInDockerDesktop() {
+				knownFeatures = append(knownFeatures, "profiles")
+			}
 			for _, feature := range knownFeatures {
 				status := "disabled"
 				if isFeatureEnabledFromCli(dockerCli, feature) {
@@ -180,7 +185,7 @@ func featureListCommand(dockerCli command.Cli) *cobra.Command {
 			if configFile.Features != nil {
 				unknownFeatures := make([]string, 0)
 				for feature := range configFile.Features {
-					if !isKnownFeature(feature) {
+					if !isKnownFeature(feature, features) {
 						unknownFeatures = append(unknownFeatures, feature)
 					}
 				}
@@ -235,13 +240,15 @@ func isFeatureEnabledFromConfig(configFile *configfile.ConfigFile, feature strin
 }
 
 // isKnownFeature checks if the feature name is valid
-func isKnownFeature(feature string) bool {
+func isKnownFeature(feature string, features features.Features) bool {
 	knownFeatures := []string{
 		"oauth-interceptor",
 		"mcp-oauth-dcr",
 		"dynamic-tools",
-		"profiles",
 		"tool-name-prefix",
+	}
+	if !features.IsRunningInDockerDesktop() {
+		knownFeatures = append(knownFeatures, "profiles")
 	}
 
 	for _, known := range knownFeatures {
@@ -250,4 +257,11 @@ func isKnownFeature(feature string) bool {
 		}
 	}
 	return false
+}
+
+func notDockerDesktop(features features.Features, msg string) string {
+	if features.IsRunningInDockerDesktop() {
+		return ""
+	}
+	return msg
 }

--- a/cmd/docker-mcp/commands/gateway.go
+++ b/cmd/docker-mcp/commands/gateway.go
@@ -210,7 +210,6 @@ func gatewayCommand(docker docker.Client, dockerCli command.Cli) *cobra.Command 
 	runCmd.Flags().StringVar(&options.Memory, "memory", options.Memory, "Memory allocated to each MCP Server (default is 2Gb)")
 	runCmd.Flags().BoolVar(&options.Static, "static", options.Static, "Enable static mode (aka pre-started servers)")
 	runCmd.Flags().StringVar(&options.LogFilePath, "log", options.LogFilePath, "Path to log file for stderr output (relative or absolute)")
-	runCmd.Flags().StringVar(&options.SessionName, "session", "", "Session name for loading and persisting configuration from ~/.docker/mcp/{SessionName}/")
 
 	// Very experimental features
 	_ = runCmd.Flags().MarkHidden("log")

--- a/cmd/docker-mcp/main.go
+++ b/cmd/docker-mcp/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/commands"
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/version"
+	"github.com/docker/mcp-gateway/pkg/features"
 )
 
 func main() {
@@ -31,7 +32,7 @@ func main() {
 	}
 
 	plugin.Run(func(dockerCli command.Cli) *cobra.Command {
-		return commands.Root(ctx, cwd, dockerCli)
+		return commands.Root(ctx, cwd, dockerCli, features.New(ctx, dockerCli))
 	},
 		manager.Metadata{
 			SchemaVersion:    "0.1.0",

--- a/docs/generator/generate.go
+++ b/docs/generator/generate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/docker/mcp-gateway/cmd/docker-mcp/commands"
+	"github.com/docker/mcp-gateway/pkg/features"
 )
 
 const defaultSourcePath = "/reference/"
@@ -35,7 +36,7 @@ func gen(opts *options) error {
 		DisableAutoGenTag: true,
 	}
 
-	cmd.AddCommand(commands.Root(context.TODO(), "", dockerCLI))
+	cmd.AddCommand(commands.Root(context.TODO(), "", dockerCLI, features.AllDisabled()))
 
 	c, err := clidocstool.New(clidocstool.Options{
 		Root:      cmd,

--- a/docs/generator/reference/docker_mcp_gateway_run.yaml
+++ b/docs/generator/reference/docker_mcp_gateway_run.yaml
@@ -242,16 +242,6 @@ options:
       experimentalcli: false
       kubernetes: false
       swarm: false
-    - option: session
-      value_type: string
-      description: |
-        Session name for loading and persisting configuration from ~/.docker/mcp/{SessionName}/
-      deprecated: false
-      hidden: false
-      experimental: false
-      experimentalcli: false
-      kubernetes: false
-      swarm: false
     - option: static
       value_type: bool
       default_value: "false"

--- a/docs/generator/reference/mcp_gateway_run.md
+++ b/docs/generator/reference/mcp_gateway_run.md
@@ -29,7 +29,6 @@ Run the gateway
 | `--registry`                | `stringSlice` | `[registry.yaml]`   | Paths to the registry files (absolute or relative to ~/.docker/mcp/)                                                                          |
 | `--secrets`                 | `string`      | `docker-desktop`    | Colon separated paths to search for secrets. Can be `docker-desktop` or a path to a .env file (default to using Docker Desktop's secrets API) |
 | `--servers`                 | `stringSlice` |                     | Names of the servers to enable (if non empty, ignore --registry flag)                                                                         |
-| `--session`                 | `string`      |                     | Session name for loading and persisting configuration from ~/.docker/mcp/{SessionName}/                                                       |
 | `--static`                  | `bool`        |                     | Enable static mode (aka pre-started servers)                                                                                                  |
 | `--tools`                   | `stringSlice` |                     | List of tools to enable                                                                                                                       |
 | `--tools-config`            | `stringSlice` | `[tools.yaml]`      | Paths to the tools files (absolute or relative to ~/.docker/mcp/)                                                                             |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -17,7 +17,9 @@ Profiles are decoupled from catalogs, meaning the servers in a profile can come 
 
 ## Enabling Profiles
 
-Profiles are a feature that must be enabled first:
+Profiles are a feature that must be enabled first.
+
+In Docker CE or container mode:
 
 ```bash
 # Enable the profiles feature
@@ -26,6 +28,8 @@ docker mcp feature enable profiles
 # Verify it's enabled
 docker mcp feature list
 ```
+
+If you're using Docker Desktop, you have to enable the `MCPWorkingSets` feature flag within Docker Desktop instead.
 
 Once enabled, you'll have access to:
 - `docker mcp profile` commands for managing profiles
@@ -740,7 +744,7 @@ Error: profile my-set not found
 Error: unknown command "profile" for "docker mcp"
 ```
 
-**Solution**: Enable the feature with `docker mcp feature enable profiles`
+**Solution**: In Docker CE or container mode, enable the feature with `docker mcp feature enable profiles`. In Docker Desktop, enable the `MCPWorkingSets` feature flag.
 
 ### Invalid Server Reference
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -887,7 +887,7 @@ Error: tool 'invalid_tool' not found in server 'github'
 - Full registry support in the gateway
 - Search and discovery features
 
-## Creating Catalogs from Profiles
+## Creating Catalogs
 
 The `catalog-next` command allows you to create and share catalogs:
 
@@ -900,6 +900,12 @@ docker mcp catalog-next create my-catalog --from-profile my-profile --name "My C
 
 # Create a catalog from a legacy catalog
 docker mcp catalog-next create docker-mcp-catalog --from-legacy-catalog https://desktop.docker.com/mcp/catalog/v3/catalog.json
+
+# Create a catalog with servers from other catalogs
+docker mcp catalog-next create dev-catalog --title dev-tools --server catalog://mcp/docker-mcp-catalog/github+notion+obsidian
+
+# Create a catalog with your own MCP server
+docker mcp catalog-next create my-catalog --title my-catalog --server docker://my-server:latest
 
 # List all catalogs
 docker mcp catalog-next list

--- a/pkg/catalog_next/catalog.go
+++ b/pkg/catalog_next/catalog.go
@@ -36,6 +36,7 @@ const (
 	SourcePrefixWorkingSet    = "profile:"
 	SourcePrefixLegacyCatalog = "legacy-catalog:"
 	SourcePrefixOCI           = "oci:"
+	SourcePrefixUser          = "user:"
 )
 
 type Server struct {

--- a/pkg/catalog_next/create_test.go
+++ b/pkg/catalog_next/create_test.go
@@ -41,7 +41,7 @@ func TestCreateFromWorkingSet(t *testing.T) {
 
 	// Capture stdout to verify the output message
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, "test/catalog:latest", "test-ws", "", "My Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog:latest", []string{}, "test-ws", "", "My Catalog")
 		require.NoError(t, err)
 	})
 
@@ -84,7 +84,7 @@ func TestCreateFromWorkingSetNormalizedRef(t *testing.T) {
 
 	// Capture stdout to verify the output message
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, "docker.io/test/catalog:latest", "test-ws", "", "My Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "docker.io/test/catalog:latest", []string{}, "test-ws", "", "My Catalog")
 		require.NoError(t, err)
 	})
 
@@ -115,7 +115,7 @@ func TestCreateFromWorkingSetRejectsDigestReference(t *testing.T) {
 	require.NoError(t, err)
 
 	digestRef := "test/catalog@sha256:0000000000000000000000000000000000000000000000000000000000000000"
-	err = Create(ctx, dao, digestRef, "test-ws", "", "My Catalog")
+	err = Create(ctx, dao, getMockRegistryClient(), getMockOciService(), digestRef, []string{}, "test-ws", "", "My Catalog")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "reference must be a valid OCI reference without a digest")
 }
@@ -142,7 +142,7 @@ func TestCreateFromWorkingSetWithEmptyName(t *testing.T) {
 
 	// Create catalog without providing a title (should use working set name)
 	captureStdout(t, func() {
-		err := Create(ctx, dao, "test/catalog2:latest", "test-ws", "", "")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog2:latest", []string{}, "test-ws", "", "")
 		require.NoError(t, err)
 	})
 
@@ -159,7 +159,7 @@ func TestCreateFromWorkingSetNotFound(t *testing.T) {
 	dao := setupTestDB(t)
 	ctx := t.Context()
 
-	err := Create(ctx, dao, "test/catalog3:latest", "nonexistent-ws", "", "Test")
+	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog3:latest", []string{}, "nonexistent-ws", "", "Test")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "profile nonexistent-ws not found")
 }
@@ -186,12 +186,12 @@ func TestCreateFromWorkingSetDuplicate(t *testing.T) {
 
 	// Create catalog from working set
 	captureStdout(t, func() {
-		err := Create(ctx, dao, "test/catalog4:latest", "test-ws", "", "Test")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog4:latest", []string{}, "test-ws", "", "Test")
 		require.NoError(t, err)
 	})
 
 	// Create with same ref again - should succeed and replace (upsert behavior)
-	err = Create(ctx, dao, "test/catalog4:latest", "test-ws", "", "Test Updated")
+	err = Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog4:latest", []string{}, "test-ws", "", "Test Updated")
 	require.NoError(t, err)
 
 	// Verify it was updated
@@ -232,7 +232,7 @@ func TestCreateFromWorkingSetWithSnapshot(t *testing.T) {
 
 	// Create catalog from working set
 	captureStdout(t, func() {
-		err := Create(ctx, dao, "test/catalog5:latest", "test-ws", "", "Test")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog5:latest", []string{}, "test-ws", "", "Test")
 		require.NoError(t, err)
 	})
 
@@ -264,7 +264,7 @@ func TestCreateFromWorkingSetEmptyServers(t *testing.T) {
 
 	// Create catalog from empty working set
 	captureStdout(t, func() {
-		err := Create(ctx, dao, "test/catalog7:latest", "empty-ws", "", "Empty Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog7:latest", []string{}, "empty-ws", "", "Empty Catalog")
 		require.NoError(t, err)
 	})
 
@@ -314,7 +314,7 @@ func TestCreateFromWorkingSetPreservesAllServerFields(t *testing.T) {
 
 	// Create catalog
 	captureStdout(t, func() {
-		err := Create(ctx, dao, "test/catalog8:latest", "detailed-ws", "", "Detailed Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/catalog8:latest", []string{}, "detailed-ws", "", "Detailed Catalog")
 		require.NoError(t, err)
 	})
 
@@ -369,7 +369,7 @@ registry:
 
 	// Create catalog from legacy catalog
 	output := captureStdout(t, func() {
-		err := Create(ctx, dao, "test/imported:latest", "", catalogFile, "Imported Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/imported:latest", []string{}, "", catalogFile, "Imported Catalog")
 		require.NoError(t, err)
 	})
 
@@ -420,7 +420,7 @@ registry:
 
 	// Create catalog from legacy catalog (first time)
 	output1 := captureStdout(t, func() {
-		err := Create(ctx, dao, "test/legacy3:latest", "", catalogFile, "Test Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy3:latest", []string{}, "", catalogFile, "Test Catalog")
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output1, "test/legacy3:latest created")
@@ -433,7 +433,7 @@ registry:
 
 	// Create with same ref again (upsert) - should replace
 	output2 := captureStdout(t, func() {
-		err := Create(ctx, dao, "test/legacy3:latest", "", catalogFile, "Test Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy3:latest", []string{}, "", catalogFile, "Test Catalog")
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output2, "test/legacy3:latest created")
@@ -471,7 +471,7 @@ registry:
 
 	// Create catalog from legacy catalog (first time)
 	output1 := captureStdout(t, func() {
-		err := Create(ctx, dao, "test/legacy4:latest", "", catalogFile, "Test Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy4:latest", []string{}, "", catalogFile, "Test Catalog")
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output1, "test/legacy4:latest created")
@@ -495,7 +495,7 @@ registry:
 
 	// Create with same ref again (upsert) - should replace with new content
 	output2 := captureStdout(t, func() {
-		err := Create(ctx, dao, "test/legacy4:latest", "", catalogFile, "Test Catalog")
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/legacy4:latest", []string{}, "", catalogFile, "Test Catalog")
 		require.NoError(t, err)
 	})
 	assert.Contains(t, output2, "test/legacy4:latest created")
@@ -510,6 +510,208 @@ registry:
 	assert.NotEqual(t, firstDigest, catalog.Digest)
 	assert.Equal(t, "Test Catalog", catalog.Title)
 	assert.Equal(t, "legacy-catalog:test-catalog", catalog.Source)
+}
+
+func TestCreateFromServersWithDockerImages(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	output := captureStdout(t, func() {
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/docker-images:latest", []string{
+			"docker://myimage:latest",
+			"docker://anotherimage:v1.0",
+		}, "", "", "Docker Images Catalog")
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Catalog test/docker-images:latest created")
+
+	// Verify the catalog was created
+	retrieved, err := dao.GetCatalog(ctx, "test/docker-images:latest")
+	require.NoError(t, err)
+
+	catalog := NewFromDb(retrieved)
+	assert.Equal(t, "Docker Images Catalog", catalog.Title)
+	assert.Equal(t, "user:cli", catalog.Source)
+	assert.Len(t, catalog.Servers, 2)
+
+	assert.Equal(t, workingset.ServerTypeImage, catalog.Servers[0].Type)
+	assert.Equal(t, "myimage:latest", catalog.Servers[0].Image)
+
+	assert.Equal(t, workingset.ServerTypeImage, catalog.Servers[1].Type)
+	assert.Equal(t, "anotherimage:v1.0", catalog.Servers[1].Image)
+}
+
+func TestCreateFromCatalogEntries(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	// Create a catalog to pull from
+	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "source-catalog", []string{
+		"docker://myimage:latest",
+	}, "", "", "Source Catalog")
+	require.NoError(t, err)
+
+	output := captureStdout(t, func() {
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "target-catalog", []string{
+			"catalog://source-catalog/My Image",
+		}, "", "", "Target Catalog")
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Catalog target-catalog:latest created")
+
+	// Verify the catalog was created
+	retrieved, err := dao.GetCatalog(ctx, "target-catalog:latest")
+	require.NoError(t, err)
+
+	catalog := NewFromDb(retrieved)
+	assert.Equal(t, "Target Catalog", catalog.Title)
+	assert.Len(t, catalog.Servers, 1)
+
+	assert.Equal(t, workingset.ServerTypeImage, catalog.Servers[0].Type)
+	assert.Equal(t, "myimage:latest", catalog.Servers[0].Image)
+}
+
+func TestCreateFromServersWithRegistryServers(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	output := captureStdout(t, func() {
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/registry-servers:latest", []string{
+			"https://example.com/v0/servers/server1",
+			"https://example.com/v0/servers/server2",
+		}, "", "", "Registry Servers Catalog")
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Catalog test/registry-servers:latest created")
+
+	// Verify the catalog was created
+	retrieved, err := dao.GetCatalog(ctx, "test/registry-servers:latest")
+	require.NoError(t, err)
+
+	catalog := NewFromDb(retrieved)
+	assert.Equal(t, "Registry Servers Catalog", catalog.Title)
+	assert.Len(t, catalog.Servers, 2)
+
+	assert.Equal(t, workingset.ServerTypeRegistry, catalog.Servers[0].Type)
+	assert.Equal(t, "https://example.com/v0/servers/server1/versions/0.1.0", catalog.Servers[0].Source)
+
+	assert.Equal(t, workingset.ServerTypeRegistry, catalog.Servers[1].Type)
+	assert.Equal(t, "https://example.com/v0/servers/server2/versions/0.1.0", catalog.Servers[1].Source)
+}
+
+func TestCreateFromServersWithMixedServers(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	output := captureStdout(t, func() {
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/mixed-servers:latest", []string{
+			"docker://myimage:latest",
+			"https://example.com/v0/servers/server1",
+		}, "", "", "Mixed Servers Catalog")
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Catalog test/mixed-servers:latest created")
+
+	// Verify the catalog was created
+	retrieved, err := dao.GetCatalog(ctx, "test/mixed-servers:latest")
+	require.NoError(t, err)
+
+	catalog := NewFromDb(retrieved)
+	assert.Equal(t, "Mixed Servers Catalog", catalog.Title)
+	assert.Len(t, catalog.Servers, 2)
+
+	assert.Equal(t, workingset.ServerTypeImage, catalog.Servers[0].Type)
+	assert.Equal(t, workingset.ServerTypeRegistry, catalog.Servers[1].Type)
+}
+
+func TestCreateFromServersWithInvalidFormat(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/invalid:latest", []string{
+		"invalid-format",
+	}, "", "", "Invalid Catalog")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid server value")
+}
+
+func TestCreateFromServersWithEmptyServers(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	output := captureStdout(t, func() {
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/empty-servers:latest", []string{}, "", "", "Empty Servers Catalog")
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Catalog test/empty-servers:latest created")
+
+	// Verify the catalog was created with no servers
+	retrieved, err := dao.GetCatalog(ctx, "test/empty-servers:latest")
+	require.NoError(t, err)
+
+	catalog := NewFromDb(retrieved)
+	assert.Equal(t, "Empty Servers Catalog", catalog.Title)
+	assert.Empty(t, catalog.Servers)
+}
+
+func TestCreateFromServersRequiresTitle(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/no-title:latest", []string{
+		"docker://myimage:latest",
+	}, "", "", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "title is required")
+}
+
+func TestCreateFromServersAddsToExistingWorkingSet(t *testing.T) {
+	dao := setupTestDB(t)
+	ctx := t.Context()
+
+	// Create a working set first
+	ws := db.WorkingSet{
+		ID:   "test-ws",
+		Name: "Test Working Set",
+		Servers: db.ServerList{
+			{
+				Type:  string(workingset.ServerTypeImage),
+				Image: "docker/existing:latest",
+			},
+		},
+		Secrets: db.SecretMap{},
+	}
+
+	err := dao.CreateWorkingSet(ctx, ws)
+	require.NoError(t, err)
+
+	// Create catalog from working set AND add additional servers
+	output := captureStdout(t, func() {
+		err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/combined:latest", []string{
+			"docker://myimage:latest",
+		}, "test-ws", "", "Combined Catalog")
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Catalog test/combined:latest created")
+
+	// Verify the catalog was created with both servers
+	retrieved, err := dao.GetCatalog(ctx, "test/combined:latest")
+	require.NoError(t, err)
+
+	catalog := NewFromDb(retrieved)
+	assert.Equal(t, "Combined Catalog", catalog.Title)
+	assert.Len(t, catalog.Servers, 2)
+
+	// First server from working set
+	assert.Equal(t, "docker/existing:latest", catalog.Servers[0].Image)
+	// Second server from additional servers
+	assert.Equal(t, "myimage:latest", catalog.Servers[1].Image)
 }
 
 func TestCreateFromLegacyCatalogWithRemotes(t *testing.T) {
@@ -695,7 +897,7 @@ func TestCreateFromLegacyCatalogWithRemotes(t *testing.T) {
 
 			// Create catalog from legacy catalog
 			output := captureStdout(t, func() {
-				err := Create(ctx, dao, "test/imported:latest", "", catalogFile, "Imported Catalog")
+				err := Create(ctx, dao, getMockRegistryClient(), getMockOciService(), "test/imported:latest", []string{}, "", catalogFile, "Imported Catalog")
 				require.NoError(t, err)
 			})
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,96 @@
+package features
+
+import (
+	"context"
+	"os"
+
+	"github.com/docker/cli/cli/command"
+
+	"github.com/docker/mcp-gateway/pkg/desktop"
+	"github.com/docker/mcp-gateway/pkg/docker"
+)
+
+type Features interface {
+	InitError() error
+	IsProfilesFeatureEnabled() bool
+	IsRunningInDockerDesktop() bool
+}
+
+type featuresImpl struct {
+	initErr              error
+	runningDockerDesktop bool
+	profilesEnabled      bool
+}
+
+var _ Features = &featuresImpl{}
+
+func New(ctx context.Context, dockerCli command.Cli) (result Features) {
+	features := &featuresImpl{}
+	result = features
+
+	features.runningDockerDesktop, features.initErr = isRunningInDockerDesktop(ctx, dockerCli)
+	if features.initErr != nil {
+		return
+	}
+
+	features.profilesEnabled, features.initErr = readProfilesFeature(ctx, dockerCli, features.runningDockerDesktop)
+	return
+}
+
+func AllEnabled() Features {
+	return &featuresImpl{
+		runningDockerDesktop: true,
+		profilesEnabled:      true,
+	}
+}
+
+func AllDisabled() Features {
+	return &featuresImpl{
+		runningDockerDesktop: false,
+		profilesEnabled:      false,
+	}
+}
+
+func (f *featuresImpl) InitError() error {
+	return f.initErr
+}
+
+func (f *featuresImpl) IsProfilesFeatureEnabled() bool {
+	return f.profilesEnabled
+}
+
+func (f *featuresImpl) IsRunningInDockerDesktop() bool {
+	return f.runningDockerDesktop
+}
+
+func isRunningInDockerDesktop(ctx context.Context, dockerCli command.Cli) (bool, error) {
+	runningInDockerCE, err := docker.RunningInDockerCE(ctx, dockerCli)
+	if err != nil {
+		return false, err
+	}
+
+	return !runningInDockerCE && os.Getenv("DOCKER_MCP_IN_CONTAINER") != "1", nil
+}
+
+func readProfilesFeature(ctx context.Context, dockerCli command.Cli, runningDockerDesktop bool) (bool, error) {
+	if runningDockerDesktop {
+		// Check DD feature flag
+		return desktop.CheckProfilesFeatureIsEnabled(ctx)
+	}
+
+	// Otherwise, check the profiles feature in Docker CE or in a container
+	return isProfilesCLIFeatureEnabled(dockerCli), nil
+}
+
+func isProfilesCLIFeatureEnabled(dockerCli command.Cli) bool {
+	configFile := dockerCli.ConfigFile()
+	if configFile == nil || configFile.Features == nil {
+		return false
+	}
+
+	value, exists := configFile.Features["profiles"]
+	if !exists {
+		return false
+	}
+	return value == "enabled"
+}

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -159,7 +159,7 @@ func (g *Gateway) listCapabilities(ctx context.Context, serverNames []string, cl
 						capabilities.Tools = append(capabilities.Tools, ToolRegistration{
 							ServerName: serverConfig.Name,
 							Tool:       &prefixedTool,
-							Handler:    g.mcpServerToolHandler(serverConfig.Name, g.mcpServer, tool.Annotations),
+							Handler:    g.mcpServerToolHandler(serverConfig.Name, g.mcpServer, tool.Annotations, tool.Name),
 						})
 					}
 				}

--- a/pkg/gateway/capabilitites.go
+++ b/pkg/gateway/capabilitites.go
@@ -80,7 +80,7 @@ func prefixToolName(prefix, toolName string) string {
 	if prefix == "" {
 		return toolName
 	}
-	return prefix + ":" + toolName
+	return prefix + "__" + toolName
 }
 
 func (caps *Capabilities) getPromptByName(promptName string) (PromptRegistration, error) {

--- a/pkg/gateway/config.go
+++ b/pkg/gateway/config.go
@@ -11,7 +11,6 @@ type Config struct {
 	RegistryPath       []string
 	ToolsPath          []string
 	SecretsPath        string
-	SessionName        string           // Session name for persisting configuration
 	MCPRegistryServers []catalog.Server // catalog.Server objects from MCP registries
 }
 

--- a/pkg/gateway/configuration.go
+++ b/pkg/gateway/configuration.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"gopkg.in/yaml.v3"
 
 	"github.com/docker/mcp-gateway/pkg/catalog"
 	"github.com/docker/mcp-gateway/pkg/config"
@@ -30,7 +29,6 @@ type Configuration struct {
 	config      map[string]map[string]any
 	tools       config.ToolsConfig
 	secrets     map[string]string
-	SessionName string
 }
 
 func (c *Configuration) ServerNames() []string {
@@ -92,51 +90,6 @@ func (c *Configuration) Find(serverName string) (*catalog.ServerConfig, *map[str
 	return nil, &byName, true
 }
 
-// Persist writes the configuration files to the session directory if SessionName is set
-func (c *Configuration) Persist() error {
-	if c.SessionName == "" {
-		return nil // No session name set, nothing to persist
-	}
-
-	// Serialize and write registry.yaml
-	registry := config.Registry{
-		Servers: make(map[string]config.Tile),
-	}
-	for _, serverName := range c.serverNames {
-		registry.Servers[serverName] = config.Tile{
-			Ref: serverName,
-		}
-	}
-	registryBytes, err := yaml.Marshal(registry)
-	if err != nil {
-		return fmt.Errorf("failed to marshal registry: %w", err)
-	}
-	if err := config.WriteConfigFileToSession(c.SessionName, "registry.yaml", registryBytes); err != nil {
-		return fmt.Errorf("failed to write registry.yaml: %w", err)
-	}
-
-	// Serialize and write config.yaml
-	configBytes, err := yaml.Marshal(c.config)
-	if err != nil {
-		return fmt.Errorf("failed to marshal config: %w", err)
-	}
-	if err := config.WriteConfigFileToSession(c.SessionName, "config.yaml", configBytes); err != nil {
-		return fmt.Errorf("failed to write config.yaml: %w", err)
-	}
-
-	// Serialize and write tools.yaml
-	toolsBytes, err := yaml.Marshal(c.tools)
-	if err != nil {
-		return fmt.Errorf("failed to marshal tools: %w", err)
-	}
-	if err := config.WriteConfigFileToSession(c.SessionName, "tools.yaml", toolsBytes); err != nil {
-		return fmt.Errorf("failed to write tools.yaml: %w", err)
-	}
-
-	log.Log(fmt.Sprintf("  - Configuration persisted to session '%s'", c.SessionName))
-	return nil
-}
-
 type FileBasedConfiguration struct {
 	CatalogPath        []string
 	ServerNames        []string // Takes precedence over the RegistryPath
@@ -148,7 +101,6 @@ type FileBasedConfiguration struct {
 	MCPRegistryServers []catalog.Server // Servers fetched from MCP registries
 	Watch              bool
 	McpOAuthDcrEnabled bool
-	sessionName        string // Session name for persisting configuration
 
 	docker docker.Client
 }

--- a/pkg/gateway/handlers.go
+++ b/pkg/gateway/handlers.go
@@ -57,7 +57,7 @@ func (g *Gateway) mcpToolHandler(tool catalog.Tool) mcp.ToolHandler {
 	}
 }
 
-func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, annotations *mcp.ToolAnnotations) mcp.ToolHandler {
+func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, annotations *mcp.ToolAnnotations, originalToolName string) mcp.ToolHandler {
 	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		// Look up server configuration
 		serverConfig, _, ok := g.configuration.Find(serverName)
@@ -128,7 +128,7 @@ func (g *Gateway) mcpServerToolHandler(serverName string, server *mcp.Server, an
 		}
 		params := &mcp.CallToolParams{
 			Meta:      req.Params.Meta,
-			Name:      req.Params.Name,
+			Name:      originalToolName,
 			Arguments: args,
 		}
 

--- a/pkg/gateway/mcpadd.go
+++ b/pkg/gateway/mcpadd.go
@@ -244,11 +244,6 @@ func (g *Gateway) createMcpAddTool(clientConfig *clientConfig) *ToolRegistration
 			g.capabilitiesMu.Unlock()
 		}
 
-		// Persist configuration if session name is set
-		if err := g.configuration.Persist(); err != nil {
-			log.Log("Warning: Failed to persist configuration:", err)
-		}
-
 		// Get the list of tools that were just added from this server
 		var addedTools []*mcp.Tool
 		g.capabilitiesMu.RLock()

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -122,9 +122,6 @@ func TestMigrateConfig_SuccessWithServers(t *testing.T) {
 	// Verify secrets
 	assert.Len(t, workingSets[0].Secrets, 1)
 	assert.Equal(t, "docker-desktop-store", workingSets[0].Secrets["default"].Provider)
-
-	// Verify legacy files were backed up
-	assertLegacyFilesBackedUp(t, mcpDir)
 }
 
 func TestMigrateConfig_SuccessWithSingleServer(t *testing.T) {
@@ -184,9 +181,6 @@ func TestMigrateConfig_SkipsWithNoServers(t *testing.T) {
 	workingSets, err := dao.ListWorkingSets(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, workingSets)
-
-	// Verify legacy files were still backed up
-	assertLegacyFilesBackedUp(t, mcpDir)
 }
 
 func TestMigrateConfig_FailureReadingLegacyFiles(t *testing.T) {
@@ -485,18 +479,6 @@ func TestMigrateConfig_LegacyFilesBackedUpOnSuccess(t *testing.T) {
 	status, err := dao.GetMigrationStatus(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, MigrationStatusSuccess, status.Status)
-
-	// Verify all legacy files were backed up
-	assertLegacyFilesBackedUp(t, mcpDir)
-
-	// Verify catalog.json was also backed up
-	backupCatalogIndexPath := filepath.Join(mcpDir, ".backup", "catalog.json")
-	_, err = os.Stat(backupCatalogIndexPath)
-	assert.False(t, os.IsNotExist(err), "catalog.json should be backed up")
-
-	// Verify original catalog.json no longer exists
-	_, err = os.Stat(catalogIndexPath)
-	assert.True(t, os.IsNotExist(err), "original catalog.json should be removed")
 }
 
 // Helper functions
@@ -544,50 +526,6 @@ func writeCatalogFile(t *testing.T, mcpDir string, serverNames []string) {
 
 	err = os.WriteFile(filepath.Join(catalogsDir, legacycatalog.DockerCatalogFilename), []byte(catalogYaml), 0o644)
 	require.NoError(t, err)
-}
-
-func assertLegacyFilesBackedUp(t *testing.T, mcpDir string) {
-	t.Helper()
-
-	backupDir := filepath.Join(mcpDir, ".backup")
-
-	// Verify backup directory exists
-	_, err := os.Stat(backupDir)
-	assert.False(t, os.IsNotExist(err), "backup directory should exist")
-
-	// Verify original files no longer exist in original location
-	registryPath := filepath.Join(mcpDir, "registry.yaml")
-	_, err = os.Stat(registryPath)
-	assert.True(t, os.IsNotExist(err), "original registry.yaml should be removed")
-
-	configPath := filepath.Join(mcpDir, "config.yaml")
-	_, err = os.Stat(configPath)
-	assert.True(t, os.IsNotExist(err), "original config.yaml should be removed")
-
-	toolsPath := filepath.Join(mcpDir, "tools.yaml")
-	_, err = os.Stat(toolsPath)
-	assert.True(t, os.IsNotExist(err), "original tools.yaml should be removed")
-
-	catalogPath := filepath.Join(mcpDir, "catalogs", legacycatalog.DockerCatalogFilename)
-	_, err = os.Stat(catalogPath)
-	assert.True(t, os.IsNotExist(err), "original catalog file should be removed")
-
-	// Verify files exist in backup directory
-	backupRegistryPath := filepath.Join(backupDir, "registry.yaml")
-	_, err = os.Stat(backupRegistryPath)
-	assert.False(t, os.IsNotExist(err), "registry.yaml should be backed up")
-
-	backupConfigPath := filepath.Join(backupDir, "config.yaml")
-	_, err = os.Stat(backupConfigPath)
-	assert.False(t, os.IsNotExist(err), "config.yaml should be backed up")
-
-	backupToolsPath := filepath.Join(backupDir, "tools.yaml")
-	_, err = os.Stat(backupToolsPath)
-	assert.False(t, os.IsNotExist(err), "tools.yaml should be backed up")
-
-	backupCatalogPath := filepath.Join(backupDir, legacycatalog.DockerCatalogFilename)
-	_, err = os.Stat(backupCatalogPath)
-	assert.False(t, os.IsNotExist(err), "catalog file should be backed up")
 }
 
 // mockDockerClient is a simple mock implementation of docker.Client for testing

--- a/pkg/workingset/create.go
+++ b/pkg/workingset/create.go
@@ -53,7 +53,7 @@ func Create(ctx context.Context, dao db.DAO, registryClient registryapi.Client, 
 	}
 
 	for _, server := range servers {
-		ss, err := resolveServersFromString(ctx, registryClient, ociService, dao, server)
+		ss, err := ResolveServersFromString(ctx, registryClient, ociService, dao, server)
 		if err != nil {
 			return err
 		}

--- a/pkg/workingset/server.go
+++ b/pkg/workingset/server.go
@@ -40,7 +40,7 @@ func AddServers(ctx context.Context, dao db.DAO, registryClient registryapi.Clie
 
 	newServers := make([]Server, 0)
 	for _, server := range servers {
-		ss, err := resolveServersFromString(ctx, registryClient, ociService, dao, server)
+		ss, err := ResolveServersFromString(ctx, registryClient, ociService, dao, server)
 		if err != nil {
 			return fmt.Errorf("invalid server value: %w", err)
 		}

--- a/pkg/workingset/workingset.go
+++ b/pkg/workingset/workingset.go
@@ -262,7 +262,7 @@ func createWorkingSetID(ctx context.Context, name string, dao db.DAO) (string, e
 	return "", fmt.Errorf("failed to create profile id")
 }
 
-func resolveServersFromString(ctx context.Context, registryClient registryapi.Client, ociService oci.Service, dao db.DAO, value string) ([]Server, error) {
+func ResolveServersFromString(ctx context.Context, registryClient registryapi.Client, ociService oci.Service, dao db.DAO, value string) ([]Server, error) {
 	if v, ok := strings.CutPrefix(value, "docker://"); ok {
 		fullRef, err := ResolveImageRef(ctx, ociService, v)
 		if err != nil {

--- a/pkg/workingset/workingset_test.go
+++ b/pkg/workingset/workingset_test.go
@@ -645,7 +645,7 @@ func TestResolveServerFromString(t *testing.T) {
 					},
 				}))
 
-			server, err := resolveServersFromString(t.Context(), registryClient, ociService, dao, tt.input)
+			server, err := ResolveServersFromString(t.Context(), registryClient, ociService, dao, tt.input)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
@@ -698,7 +698,7 @@ func TestResolveServerFromStringResolvesLatestVersion(t *testing.T) {
 		"http://example.com/v0/servers/my-server/versions/0.2.0": serverResponse,
 	}))
 
-	server, err := resolveServersFromString(t.Context(), registryClient, mocks.NewMockOCIService(), dao, "http://example.com/v0/servers/my-server")
+	server, err := ResolveServersFromString(t.Context(), registryClient, mocks.NewMockOCIService(), dao, "http://example.com/v0/servers/my-server")
 	require.NoError(t, err)
 	assert.Equal(t, "http://example.com/v0/servers/my-server/versions/0.2.0", server[0].Source)
 }


### PR DESCRIPTION
This pull request refactors feature flag handling in the CLI commands for the MCP Gateway, improving consistency and testability by introducing a centralized `features.Features` interface. It also adds support for specifying multiple servers when creating a catalog and makes the "profiles" feature context-aware (hidden on Docker Desktop, available on CE). The changes touch several commands and their flags, update feature validation logic, and enhance unit tests.

**Feature flag handling improvements:**

* Replaced direct config file checks for feature flags (like "profiles") with calls to a new `features.Features` interface, which is passed into command constructors and used throughout the codebase for feature detection. This affects commands in `client.go`, `gateway.go`, and `feature.go`, and removes the old `isWorkingSetsFeatureEnabled` function. [[1]](diffhunk://#diff-461e702bccb939c1b3a2df5766124492b0e9ab0258add90f6035bff45a6e37afR15-R27) [[2]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709R15-R19) [[3]](diffhunk://#diff-1d0b1ab0dfb858c0d197a4fc80b46ef7d9c5cf1e079f4424ad7d1b161f94daf8R10-R15) [[4]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709L358-L371)
* Updated feature-related command logic and help text to dynamically show or hide the "profiles" feature depending on the runtime environment (Docker Desktop vs. CE), using the new feature detection. [[1]](diffhunk://#diff-1d0b1ab0dfb858c0d197a4fc80b46ef7d9c5cf1e079f4424ad7d1b161f94daf8L43-R53) [[2]](diffhunk://#diff-1d0b1ab0dfb858c0d197a4fc80b46ef7d9c5cf1e079f4424ad7d1b161f94daf8L154-R159) [[3]](diffhunk://#diff-1d0b1ab0dfb858c0d197a4fc80b46ef7d9c5cf1e079f4424ad7d1b161f94daf8L238-R252)

**Command and flag enhancements:**

* Added support for multiple `--server` flags to the `catalog_next create` command, allowing users to specify several servers when creating a catalog, and updated the function signature and usage accordingly. [[1]](diffhunk://#diff-948175b6256cf4eb640923eafbfb607d669811fc4965b702c103a30b413e295cR40-L48) [[2]](diffhunk://#diff-948175b6256cf4eb640923eafbfb607d669811fc4965b702c103a30b413e295cL57-R63)
* Updated flag registration and usage in several commands to use the new feature detection logic, ensuring that profile-related flags are only available when appropriate. [[1]](diffhunk://#diff-461e702bccb939c1b3a2df5766124492b0e9ab0258add90f6035bff45a6e37afL66-R67) [[2]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709L60-R61) [[3]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709L70-R71) [[4]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709L181-R182)

**Testing improvements:**

* Refactored unit tests for feature detection to use a mock implementation of the new `features.Features` interface, and added tests for the context-aware "profiles" feature. [[1]](diffhunk://#diff-d0038cd4ff4102c9494643a5a83af5e8ef2ba070f6fa5d70973df394693bb8edR8-R9) [[2]](diffhunk://#diff-d0038cd4ff4102c9494643a5a83af5e8ef2ba070f6fa5d70973df394693bb8edL118-R155)

**Codebase consistency and cleanup:**

* Updated command constructors (`clientCommand`, `gatewayCommand`, `featureCommand`) to accept a `features.Features` parameter, improving dependency injection and testability. [[1]](diffhunk://#diff-461e702bccb939c1b3a2df5766124492b0e9ab0258add90f6035bff45a6e37afR15-R27) [[2]](diffhunk://#diff-4e518114d4dad427731f385d712cbef8212dc2cf2be71c2053041c66206a6709R15-R19) [[3]](diffhunk://#diff-1d0b1ab0dfb858c0d197a4fc80b46ef7d9c5cf1e079f4424ad7d1b161f94daf8R10-R15)
* Removed the obsolete `isWorkingSetsFeatureEnabled` function and related legacy code.

These changes provide a more robust and maintainable way to manage feature flags and improve the user experience by adapting available features to the runtime environment.**What I did**

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation to what you did**